### PR TITLE
feat: add slider on product details page

### DIFF
--- a/src/pages/DetailedProduct.tsx
+++ b/src/pages/DetailedProduct.tsx
@@ -5,7 +5,11 @@ import type { ProductInteface } from '@/data/interfaces';
 import { CoffeeType } from '@/data/interfaces';
 import { simplifySingleProduct } from '@/utils/productUtils';
 import ProductSlider from '@/components/Product-components/ProductSlider';
-
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import '@/styles/productSlider.css';
 const DetailedProduct: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [product, setProduct] = useState<ProductInteface | null>(null);
@@ -108,18 +112,26 @@ const DetailedProduct: React.FC = () => {
         </div>
 
         <div className="w-full md:w-[400px] lg:w-[500px] p-2 md:p-0 flex justify-center mx-auto">
-          <div className="relative w-full max-w-[400px] group">
-            <img
-              src={product.images[0]}
-              alt={`${product.name} main image`}
-              className="w-full h-auto rounded-lg shadow-md object-cover"
-            />
-            <div
-              onClick={() => setShowSlider(true)}
-              className="cursor-pointer absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity duration-300 before:absolute before:inset-0 before:bg-black before:opacity-0 hover:before:opacity-40 before:rounded-lg before:transition-opacity before:duration-300"
-            >
-              <span className="relative z-10 text-white font-bold text-lg">Show more images</span>
-            </div>
+          <div className="relative w-full max-w-[400px] lg:max-w-[500px]">
+            <Swiper navigation={true} modules={[Navigation]} className="mySwiper">
+              {product.images.map((item, index) => (
+                <SwiperSlide key={index} className="relative group">
+                  <img
+                    src={item}
+                    alt={`Product Image ${index + 1}`}
+                    className="w-full h-[300px] sm:h-[350px] md:h-[400px] rounded-lg shadow-md object-cover"
+                  />
+
+                  <div
+                    onClick={() => setShowSlider(true)}
+                    className="cursor-pointer absolute inset-0 flex items-center justify-center transition-opacity duration-300 group-hover:opacity-100 opacity-0"
+                    style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+                  >
+                    <span className="text-white font-bold text-lg">Show more images</span>
+                  </div>
+                </SwiperSlide>
+              ))}
+            </Swiper>
           </div>
         </div>
       </div>

--- a/src/styles/productSlider.css
+++ b/src/styles/productSlider.css
@@ -15,6 +15,6 @@
 .swiper-slide img {
   display: block;
   width: 100%;
-  height: 100%;
+  border-radius: 10px;
   object-fit: cover;
 }


### PR DESCRIPTION
## Description
This PR adds a full-screen image slider to the detailed product page. Users can now:

- View product images in a swipeable gallery

- Click to expand images into a full-screen modal

- Navigate between images with smooth transitions

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Style (formatting, missing semi-colons, etc.)
- [ ] Other: **\_\_\_\_**

## Screenshot(s)

![Capture](https://github.com/user-attachments/assets/2f6f6a97-ef78-4eb0-b068-9931aa9289be)


## Rationale

<!-- Why were these changes made? What problem do they solve? -->

## Notes for the Reviewer
